### PR TITLE
Case insensitive search

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ Object.keys(data.data).forEach((key) => {
 });
 
 // find and display result
-const name = process.argv[2];
+const name = process.argv[2].toLowerCase();
 const res = findResult(name);
 
 if (res !== undefined) {


### PR DESCRIPTION
I was a bit confused that I didn't get results when searching, e.g. `caniuse IndexedDB`. This PR converts all search terms to lowercase, hence making it case-insensitive.